### PR TITLE
ci: Replace deprecated circleci image with cimg

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ commands:
 jobs:
   test:
     docker:
-      - image: circleci/python:3.10.0-node
+      - image: cimg/python:3.10.0-node
 
     steps:
       - unittests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ commands:
 jobs:
   test:
     docker:
-      - image: cimg/python:3.10.0-node
+      - image: cimg/python:3.9-node
 
     steps:
       - unittests

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
     packages=find_packages(exclude=("tests",)),
     test_suite="setup.project_test_suite",
     install_requires=[
+      'requests>=2.0.1'
       'pycircleci>=0.3.2',
       'robotframework>=4.0.0'
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py310
+envlist = py39
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist = py39
 [testenv]
 deps =
     pytest
+    pycircleci
 commands =
     pytest
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39
+envlist = py310
 
 [testenv]
 deps =


### PR DESCRIPTION
## Description
Replace deprecated circleci image with cimg.

For more information please see:
https://circleci.com/docs/2.0/next-gen-migration-guide/