### PR TITLE
ci: Replace ssh key with github token for push

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,10 +37,6 @@ jobs:
       - checkout
       - install
       - run:
-          name: Setup git push with github token
-          command: |
-            git config --global url.https://${GITHUB_TOKEN}@github.com/.insteadOf ssh://git@github.com/
-      - run:
           name: Build robotframework html docs with libdoc
           command: make generate-docs
       - run:
@@ -48,7 +44,7 @@ jobs:
           command: |
             git config user.email "no-reply@trustedshops.com"
             git config user.name "trustedshops-public-cns-bot"
-            npx gh-pages@2.0.1 --dist docs/ --message "docs: Update github pages [ci skip]"
+            npx gh-pages@2.0.1 --dist docs/ --message "docs: Update github pages [ci skip]" --repo "https://${GITHUB_TOKEN}@github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}.git"
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,8 @@ workflows:
             tags:
               only: /.*/
       - generate-docs:
+          context:
+            - semantic-release
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,9 +36,10 @@ jobs:
     steps:
       - checkout
       - install
-      - add_ssh_keys:
-          fingerprints:
-            - "9e:af:13:4f:43:96:5d:04:60:07:71:f9:05:1f:d1:e7"
+      - run:
+          name: Setup git push with github token
+          command: |
+            git config --global url.https://${GITHUB_TOKEN}@github.com/.insteadOf ssh://git@github.com/
       - run:
           name: Build robotframework html docs with libdoc
           command: make generate-docs
@@ -62,5 +63,6 @@ workflows:
             branches:
               only:
                 - main
+                - /ci\/.*/
           requires:
             - test


### PR DESCRIPTION
## Description
- Replace ssh for GitHub checkout with a token that is easier to rotate
